### PR TITLE
Fix for select box values that contain special characters.

### DIFF
--- a/drivers/ImportDriver_selectbox_link.php
+++ b/drivers/ImportDriver_selectbox_link.php
@@ -31,7 +31,7 @@ class ImportDriver_selectbox_link extends ImportDriver_default
         $related_ids = array('relation_id'=>array());
         foreach ($data as $relationValue)
         {
-            $related_ids['relation_id'][] = Symphony::Database()->fetchVar('entry_id', 0, 'SELECT `entry_id` FROM `tbl_entries_data_' . $related_field . '` WHERE `value` = \'' . trim($relationValue) . '\';');
+            $related_ids['relation_id'][] = Symphony::Database()->fetchVar('entry_id', 0, 'SELECT `entry_id` FROM `tbl_entries_data_' . $related_field . '` WHERE `value` = \'' . Symphony::Database()->cleanValue(trim($relationValue)) . '\';');
         }
         return $related_ids;
     }


### PR DESCRIPTION
Was experiencing fatal DB errors because some of my select box field data had special characters (apostrophes in this case), preventing the entry in question from being imported at all. Just uses built-in symphony DB sanitizer on field value when building relation IDs. Haven't checked if this is required for other field handlers. 
