### PR TITLE
Symphony 2.3 error with: Illegal string offset 'handle'

### DIFF
--- a/content/content.index.php
+++ b/content/content.index.php
@@ -71,9 +71,7 @@ class contentExtensionImportcsvIndex extends AdministrationPage
         $xml->appendChild($sectionsNode);
 
         // Check if the multilingual-field extension is installed:
-        $em = new ExtensionManager();
-        $status = $em->fetchStatus('multilingual_field');
-        if($status == EXTENSION_ENABLED)
+        if(in_array('multilingual_field', ExtensionManager::listInstalledHandles()))
         {
             $xml->setAttribute('multilanguage', 'yes');
             // Get all the multilanguage fields:

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -23,7 +23,7 @@ Class extension_importcsv extends Extension
 		{
 			return array(
 				array(
-					'location'	=> 'System',
+					'location'	=> __('System'),
 					'name'		=> __('Import / Export CSV'),
 					'link'		=> '/'
 				)


### PR DESCRIPTION
The call on [this line](https://github.com/kanduvisla/importcsv/blob/master/content/content.index.php#L75) creates an error in Symphony 2.3 ( _no error_ in 2.3.1) because, the method `ExtensionManager->fetchStatus($about)` **requires** $about to be an array, it doesn't work with strings.

Note that Symphony 2.3.1 changed the behavior of this function to be able to work both styles: with a string or with an array.

This pull request ensures it works consistently in 2.2, 2.3 and 2.3.1.

How to reproduce problem:
- Test on Symphony 2.3 (not 2.3.1)
- Install the [Multilingual Text Box extension](https://github.com/6ui11em/multilingual_field) and all its dependencies
- Enable Import / Export CSV
- Go to the "Import/Export CSV" page
- You should get a Symphony error "Illegal string offset 'handle'
