### PR TITLE
ensure that the default driver is loaded as the first one

### DIFF
--- a/content/content.index.php
+++ b/content/content.index.php
@@ -201,6 +201,17 @@ class contentExtensionImportcsvIndex extends AdministrationPage
     {
         $classes = glob(EXTENSIONS . '/importcsv/drivers/*.php');
         $drivers = array();
+
+        // this matching, popping grepping, and unshifting
+        // ensures that the ImportDriver_default class is the first
+        // path in the stack otherwise any driver that comes before
+        // "default" alphabetically will throw an error along
+        // the lines saying ImportDriver_default.php is undefined
+        $defaultMatch = '/ImportDriver_default\.php$/';
+        $defaultDriver = array_pop(preg_grep($defaultMatch, $classes));
+        $classes = preg_grep($defaultMatch, $classes, PREG_GREP_INVERT);
+        array_unshift($classes, $defaultDriver);
+
         foreach ($classes as $class)
         {
             include_once($class);


### PR DESCRIPTION
When creating a driver for the address location field, that driver would be loaded before the default one since this is just globbing the files from the drivers directory.  Rather than renaming the default driver and updating the references, I took the route of just ensuring that the default driver was always the first in the stack.
