### PR TITLE
changed $updated -> $ignored when ignoring import items

### DIFF
--- a/content/content.index.php
+++ b/content/content.index.php
@@ -344,7 +344,7 @@ class contentExtensionImportcsvIndex extends AdministrationPage
             $messageSuffix .= ' ' . __('(updated: ') . implode(', ', $updated) . ')';
         }
         if (count($ignored) > 0) {
-            $messageSuffix .= ' ' . __('(ignored: ') . implode(', ', $updated) . ')';
+            $messageSuffix .= ' ' . __('(ignored: ') . implode(', ', $ignored) . ')';
         }
 
         die('[OK]' . $messageSuffix);


### PR DESCRIPTION
this will output the correct IDs when doing the ajax import.  before it was just an empty array since it was trying to grab the `$updated` array.
